### PR TITLE
Fixed typo in text area descriptions

### DIFF
--- a/streamlit_sql_sandbox/streamlit_demo.py
+++ b/streamlit_sql_sandbox/streamlit_demo.py
@@ -106,10 +106,10 @@ with setup_tab:
         "Business table description", value=DEFAULT_BUSINESS_TABLE_DESCRP
     )
     violations_table_descrp = st.text_area(
-        "Business table description", value=DEFAULT_VIOLATIONS_TABLE_DESCRP
+        "Violation table description", value=DEFAULT_VIOLATIONS_TABLE_DESCRP
     )
     inspections_table_descrp = st.text_area(
-        "Business table description", value=DEFAULT_INSPECTIONS_TABLE_DESCRP
+        "Inspection table description", value=DEFAULT_INSPECTIONS_TABLE_DESCRP
     )
 
     table_context_dict = {


### PR DESCRIPTION
Fixed a typo causing confusion in the streamlit_sql_sandbox application. The 'violation' and 'inspection' tables were inaccurately labeled as 'Business table description'. 
```python
business_table_descrp = st.text_area(
    "Business table description", value=DEFAULT_BUSINESS_TABLE_DESCRP
)
violations_table_descrp = st.text_area(
    "Business table description", value=DEFAULT_VIOLATIONS_TABLE_DESCRP
)
inspections_table_descrp = st.text_area(
    "Business table description", value=DEFAULT_INSPECTIONS_TABLE_DESCRP
)
```