### PR TITLE
Update requirement.txt in flask_react and werkzeug==2.3.7

### DIFF
--- a/flask_react/requirements.txt
+++ b/flask_react/requirements.txt
@@ -3,3 +3,4 @@ Flask-Cors==3.0.10
 langchain==0.0.154
 llama-index==0.6.13
 pypdf==3.9.0
+werkzeug==2.3.7


### PR DESCRIPTION
When flask_demo doesn't work
Reason: werkzeug, which depends on flask, does not yet support version 3.0.0